### PR TITLE
Compliance with W3C

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
       Roboto is the default font for Material-UI. Baloo+Bhaijaan is only used for the logo
     -->
     <link
-      href="https://fonts.googleapis.com/css?family=Baloo+Bhaijaan|Roboto:300,400,500&display=swap"
+      href="https://fonts.googleapis.com/css?family=Baloo+Bhaijaan%7CRoboto:300,400,500&display=swap"
       rel="stylesheet"
     />
     <title>


### PR DESCRIPTION
Runned the [W3C validator](https://validator.w3.org/) and got the next error:
![Screenshot 2021-03-25 at 09 53 16](https://user-images.githubusercontent.com/3071208/112445977-03779200-8d50-11eb-9b93-8cd7e2debf42.png)
This PR solves that compliancy issue with the use of the ASCII hexadecimal code of `|`.