### PR TITLE
Fix copy/paste error with prop types

### DIFF
--- a/src/logged_in/components/subscription/AddBalanceDialog.js
+++ b/src/logged_in/components/subscription/AddBalanceDialog.js
@@ -204,7 +204,7 @@ function Wrapper(props) {
 }
 
 
-AddBalanceDialog.propTypes = {
+Wrapper.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired


### PR DESCRIPTION
Just a simple issue, this should set prop types on the `Wrapper` component instead of re-setting prop types on the underlying component